### PR TITLE
Turn off anti-aliasing of canvas context

### DIFF
--- a/index.js
+++ b/index.js
@@ -782,7 +782,7 @@ window.onload = () => {
     };
 
     const canvas = document.getElementById("preview");
-    const gl = canvas.getContext("webgl");
+    const gl = canvas.getContext("webgl", {antialias: false, alpha: false});
     if (!gl) {
         throw new Error("Could not initialize WebGL context");
     }


### PR DESCRIPTION
There's green border around scaled emotes when you render them.

<details>
<summary>
Before and after for Slide filter
</summary>

![test](https://user-images.githubusercontent.com/4366033/116798090-f5f2bc00-aaf4-11eb-8705-37a2d0149387.png)
</details>

<details>
<summary>
Before and after for Blob filter
</summary>

![testBlob](https://user-images.githubusercontent.com/4366033/116798387-8b8f4b00-aaf7-11eb-868d-f087ce702f14.png)
</details>

<details>
<summary>
image that was used for test
</summary>

![testimage](https://user-images.githubusercontent.com/4366033/116798352-30f5ef00-aaf7-11eb-84f4-d1f10c3a0ff3.png)
</details>

Also disabled alpha, because I was reading on internet that it's faster for browser to render page that way.

