### PR TITLE
fix red cross if file has no extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -859,14 +859,14 @@ window.onload = () => {
             emoteTexture = createTextureFromImage(gl, customPreview);
         };
 
+        customPreview.onerror = function() {
+            customFile.value = '';
+            this.src = 'error.png';
+        }
+
         const customFile = document.querySelector("#custom-file");
         customFile.onchange = function() {
-            if (!this.files[0].type.startsWith('image/')) {
-                customFile.value = '';
-                customPreview.src = 'error.png';
-            } else {
-                customPreview.src = URL.createObjectURL(this.files[0]);
-            }
+            customPreview.src = URL.createObjectURL(this.files[0]);
         };
 
         // drag file from anywhere


### PR DESCRIPTION
fix #35 

still doesn't work for `svg` files without extension, #18 did not break `svg`, for some reason browsers (at least Chrome & Firefox) cannot recognize it that way.