### PR TITLE
Decouple shaders from source code

### DIFF
--- a/glsl/blob.fs
+++ b/glsl/blob.fs
@@ -1,0 +1,15 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/blob.vs
+++ b/glsl/blob.vs
@@ -1,0 +1,21 @@
+#version 100
+
+precision mediump float;
+
+attribute vec2 meshPosition;
+
+uniform vec2 resolution;
+uniform float time;
+
+varying vec2 uv;
+
+void main() {
+    float stretch = sin(6.0 * time) * 0.5 + 1.0;
+
+    vec2 offset = vec2(0.0, 1.0 - stretch);
+    gl_Position = vec4(
+        meshPosition * vec2(stretch, 2.0 - stretch) + offset,
+        0.0,
+        1.0);
+    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
+}

--- a/glsl/bounce.fs
+++ b/glsl/bounce.fs
@@ -1,0 +1,15 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/bounce.vs
+++ b/glsl/bounce.vs
@@ -1,0 +1,17 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+
+uniform vec2 resolution;
+uniform float time;
+
+varying vec2 uv;
+
+void main() {
+    float scale = 0.30;
+    float period_interval = 5.0;
+    vec2 offset = vec2(0.0, (2.0 * abs(sin(time * period_interval)) - 1.0) * (1.0 - scale));
+    gl_Position = vec4(meshPosition * scale + offset, 0.0, 1.0);
+    uv = (meshPosition + 1.0) / 2.0;
+}

--- a/glsl/circle.fs
+++ b/glsl/circle.fs
@@ -1,0 +1,16 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    float speed = 1.0;
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/circle.vs
+++ b/glsl/circle.vs
@@ -1,0 +1,29 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+
+uniform vec2 resolution;
+uniform float time;
+
+varying vec2 uv;
+
+vec2 rotate(vec2 v, float a) {
+    float s = sin(a);
+    float c = cos(a);
+    mat2 m = mat2(c, -s, s, c);
+    return m * v;
+}
+
+void main() {
+    float scale = 0.30;
+    float period_interval = 8.0;
+    float pi = 3.141592653589793238;
+    vec2 outer_circle = vec2(cos(period_interval * time), sin(period_interval * time)) * (1.0 - scale);
+    vec2 inner_circle = rotate(meshPosition * scale, (-period_interval * time) + pi / 2.0);
+    gl_Position = vec4(
+        inner_circle + outer_circle,
+        0.0,
+        1.0);
+    uv = (meshPosition + 1.0) / 2.0;
+}

--- a/glsl/elevator.fs
+++ b/glsl/elevator.fs
@@ -1,0 +1,22 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+float slide(float speed, float value) {
+    return mod(value - speed * time, 1.0);
+}
+
+void main() {
+    float speed = 4.0;
+    gl_FragColor = texture2D(
+        emote,
+        vec2(uv.x, slide(speed, 1.0 - uv.y)));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/elevator.vs
+++ b/glsl/elevator.vs
@@ -1,0 +1,14 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+
+uniform vec2 resolution;
+uniform float time;
+
+varying vec2 uv;
+
+void main() {
+    gl_Position = vec4(meshPosition, 0.0, 1.0);
+    uv = (meshPosition + 1.0) / 2.0;
+}

--- a/glsl/go.fs
+++ b/glsl/go.fs
@@ -1,0 +1,20 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+float slide(float speed, float value) {
+    return mod(value - speed * time, 1.0);
+}
+
+void main() {
+    float speed = 4.0;
+    gl_FragColor = texture2D(emote, vec2(slide(speed, uv.x), 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/go.vs
+++ b/glsl/go.vs
@@ -1,0 +1,14 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+
+uniform vec2 resolution;
+uniform float time;
+
+varying vec2 uv;
+
+void main() {
+    gl_Position = vec4(meshPosition, 0.0, 1.0);
+    uv = (meshPosition + 1.0) / 2.0;
+}

--- a/glsl/hard.fs
+++ b/glsl/hard.fs
@@ -1,0 +1,15 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/hard.vs
+++ b/glsl/hard.vs
@@ -1,0 +1,18 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+
+uniform vec2 resolution;
+uniform float time;
+
+varying vec2 uv;
+
+void main() {
+    float zoom = 1.4;
+    float intensity = 32.0;
+    float amplitude = 1.0 / 8.0;
+    vec2 shaking = vec2(cos(intensity * time), sin(intensity * time)) * amplitude;
+    gl_Position = vec4(meshPosition * zoom + shaking, 0.0, 1.0);
+    uv = (meshPosition + 1.0) / 2.0;
+}

--- a/glsl/hop.fs
+++ b/glsl/hop.fs
@@ -1,0 +1,15 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/hop.vs
+++ b/glsl/hop.vs
@@ -1,0 +1,35 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+uniform float time;
+
+varying vec2 uv;
+
+float sliding_from_left_to_right(float time_interval) {
+    return (mod(time, time_interval) - time_interval * 0.5) / (time_interval * 0.5);
+}
+
+float flipping_directions(float time_interval) {
+    return 1.0 - 2.0 * mod(floor(time / time_interval), 2.0);
+}
+
+void main() {
+    float scale = 0.40;
+    float hops = 2.0;
+    float x_time_interval = 0.85;
+    float y_time_interval = x_time_interval / (2.0 * hops);
+    float height = 0.5;
+    vec2 offset = vec2(
+        sliding_from_left_to_right(x_time_interval) * flipping_directions(x_time_interval) * (1.0 - scale),
+        ((sliding_from_left_to_right(y_time_interval) * flipping_directions(y_time_interval) + 1.0) / 4.0) - height);
+
+    gl_Position = vec4(
+        meshPosition * scale + offset,
+        0.0,
+        1.0);
+
+    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
+
+    uv.x = (flipping_directions(x_time_interval) + 1.0) / 2.0 - uv.x * flipping_directions(x_time_interval);
+}

--- a/glsl/hopper.fs
+++ b/glsl/hopper.fs
@@ -1,0 +1,15 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/hopper.vs
+++ b/glsl/hopper.vs
@@ -1,0 +1,35 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+uniform float time;
+
+varying vec2 uv;
+
+float sliding_from_left_to_right(float time_interval) {
+    return (mod(time, time_interval) - time_interval * 0.5) / (time_interval * 0.5);
+}
+
+float flipping_directions(float time_interval) {
+    return 1.0 - 2.0 * mod(floor(time / time_interval), 2.0);
+}
+
+void main() {
+    float scale = 0.40;
+    float hops = 2.0;
+    float x_time_interval = 0.85 / 2.0;
+    float y_time_interval = x_time_interval / (2.0 * hops);
+    float height = 0.5;
+    vec2 offset = vec2(
+        sliding_from_left_to_right(x_time_interval) * flipping_directions(x_time_interval) * (1.0 - scale),
+        ((sliding_from_left_to_right(y_time_interval) * flipping_directions(y_time_interval) + 1.0) / 4.0) - height);
+
+    gl_Position = vec4(
+        meshPosition * scale + offset,
+        0.0,
+        1.0);
+
+    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
+
+    uv.x = (flipping_directions(x_time_interval) + 1.0) / 2.0 - uv.x * flipping_directions(x_time_interval);
+}

--- a/glsl/laughing.fs
+++ b/glsl/laughing.fs
@@ -1,0 +1,15 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/laughing.vs
+++ b/glsl/laughing.vs
@@ -1,0 +1,18 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+uniform float time;
+
+varying vec2 uv;
+
+void main() {
+    float a = 0.3;
+    float t = (sin(24.0 * time) * a + a) / 2.0;
+
+    gl_Position = vec4(
+        meshPosition - vec2(0.0, t),
+        0.0,
+        1.0);
+    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
+}

--- a/glsl/overheat.fs
+++ b/glsl/overheat.fs
@@ -1,0 +1,15 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y)) * vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/overheat.vs
+++ b/glsl/overheat.vs
@@ -1,0 +1,35 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+uniform float time;
+
+varying vec2 uv;
+
+float sliding_from_left_to_right(float time_interval) {
+    return (mod(time, time_interval) - time_interval * 0.5) / (time_interval * 0.5);
+}
+
+float flipping_directions(float time_interval) {
+    return 1.0 - 2.0 * mod(floor(time / time_interval), 2.0);
+}
+
+void main() {
+    float scale = 0.40;
+    float hops = 2.0;
+    float x_time_interval = 0.85 / 8.0;
+    float y_time_interval = x_time_interval / (2.0 * hops);
+    float height = 0.5;
+    vec2 offset = vec2(
+        sliding_from_left_to_right(x_time_interval) * flipping_directions(x_time_interval) * (1.0 - scale),
+        ((sliding_from_left_to_right(y_time_interval) * flipping_directions(y_time_interval) + 1.0) / 4.0) - height);
+
+    gl_Position = vec4(
+        meshPosition * scale + offset,
+        0.0,
+        1.0);
+
+    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
+
+    uv.x = (flipping_directions(x_time_interval) + 1.0) / 2.0 - uv.x * flipping_directions(x_time_interval);
+}

--- a/glsl/peek.fs
+++ b/glsl/peek.fs
@@ -1,0 +1,15 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/peek.vs
+++ b/glsl/peek.vs
@@ -1,0 +1,25 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+
+uniform vec2 resolution;
+uniform float time;
+
+varying vec2 uv;
+
+void main() {
+    float time_clipped= mod(time * 2.0, (4.0 * 3.14));
+
+    float s1 = float(time_clipped < (2.0 * 3.14));
+    float s2 = 1.0 - s1;
+
+    float hold1 = float(time_clipped > (0.5 * 3.14) && time_clipped < (2.0 * 3.14));
+    float hold2 = 1.0 - float(time_clipped > (2.5 * 3.14) && time_clipped < (4.0 * 3.14));
+
+    float cycle_1 = 1.0 - ((s1 * sin(time_clipped) * (1.0 - hold1)) + hold1);
+    float cycle_2 = s2 * hold2 * (sin(time_clipped) - 1.0); 
+
+    gl_Position = vec4(meshPosition.x + 1.0 + cycle_1 + cycle_2 , meshPosition.y, 0.0, 1.0);
+    uv = (meshPosition + 1.0) / 2.0;
+}

--- a/glsl/pride.fs
+++ b/glsl/pride.fs
@@ -1,0 +1,25 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+vec3 hsl2rgb(vec3 c) {
+    vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),6.0)-3.0)-1.0, 0.0, 1.0);
+    return c.z + c.y * (rgb-0.5)*(1.0-abs(2.0*c.z-1.0));
+}
+
+void main() {
+    float speed = 1.0;
+
+    vec4 pixel = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    pixel.w = floor(pixel.w + 0.5);
+    pixel = vec4(mix(vec3(1.0), pixel.xyz, pixel.w), 1.0);
+    vec4 rainbow = vec4(hsl2rgb(vec3((time - uv.x - uv.y) * 0.5, 1.0, 0.80)), 1.0);
+    gl_FragColor = pixel * rainbow;
+}

--- a/glsl/pride.vs
+++ b/glsl/pride.vs
@@ -1,0 +1,14 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+
+uniform vec2 resolution;
+uniform float time;
+
+varying vec2 uv;
+
+void main() {
+    gl_Position = vec4(meshPosition, 0.0, 1.0);
+    uv = (meshPosition + 1.0) / 2.0;
+}

--- a/glsl/rain.fs
+++ b/glsl/rain.fs
@@ -1,0 +1,23 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+float slide(float speed, float value) {
+    return mod(value - speed * time, 1.0);
+}
+
+void main() {
+    float speed = 1.0;
+    gl_FragColor = texture2D(
+        emote,
+        vec2(mod(4.0 * slide(speed, uv.x), 1.0),
+             mod(4.0 * slide(speed, 1.0 - uv.y), 1.0)));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/rain.vs
+++ b/glsl/rain.vs
@@ -1,0 +1,14 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+
+uniform vec2 resolution;
+uniform float time;
+
+varying vec2 uv;
+
+void main() {
+    gl_Position = vec4(meshPosition, 0.0, 1.0);
+    uv = (meshPosition + 1.0) / 2.0;
+}

--- a/glsl/slide.fs
+++ b/glsl/slide.fs
@@ -1,0 +1,15 @@
+#version 100
+
+precision mediump float;
+
+uniform vec2 resolution;
+uniform float time;
+
+uniform sampler2D emote;
+
+varying vec2 uv;
+
+void main() {
+    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
+    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
+}

--- a/glsl/slide.vs
+++ b/glsl/slide.vs
@@ -1,0 +1,35 @@
+#version 100
+precision mediump float;
+
+attribute vec2 meshPosition;
+uniform float time;
+
+varying vec2 uv;
+
+float sliding_from_left_to_right(float time_interval) {
+    return (mod(time, time_interval) - time_interval * 0.5) / (time_interval * 0.5);
+}
+
+float flipping_directions(float time_interval) {
+    return 1.0 - 2.0 * mod(floor(time / time_interval), 2.0);
+}
+
+void main() {
+    float scale = 0.40;
+    float hops = 2.0;
+    float x_time_interval = 0.85;
+    float y_time_interval = x_time_interval / (2.0 * hops);
+    float height = 0.5;
+    vec2 offset = vec2(
+        sliding_from_left_to_right(x_time_interval) * flipping_directions(x_time_interval) * (1.0 - scale),
+        - height);
+
+    gl_Position = vec4(
+        meshPosition * scale + offset,
+        0.0,
+        1.0);
+
+    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
+
+    uv.x = (flipping_directions(x_time_interval) + 1.0) / 2.0 - uv.x * flipping_directions(x_time_interval);
+}

--- a/index.html
+++ b/index.html
@@ -23,8 +23,8 @@
     <h2>2. Select a Filter</h2>
     <p>The image below is not a GIF yet. It's just a preview of how the filter looks like when applied to the image you've selected. Try different filters and pick the one you want.</p>
 
-    <div class="widget">
-      <div class="widget-element">
+    <div class="widget" id="widget-filter">
+      <div class="widget-element" id="select-filters">
         Filter: <select id="filters"></select>
       </div>
       <canvas id="preview" width="112" height="112" class="widget-element"></canvas>

--- a/index.js
+++ b/index.js
@@ -44,659 +44,86 @@ const filters = {
     "Hop": {
         "transparent": 0x00FF00,
         "duration": 0.85 * 2,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-uniform float time;
-
-varying vec2 uv;
-
-float sliding_from_left_to_right(float time_interval) {
-    return (mod(time, time_interval) - time_interval * 0.5) / (time_interval * 0.5);
-}
-
-float flipping_directions(float time_interval) {
-    return 1.0 - 2.0 * mod(floor(time / time_interval), 2.0);
-}
-
-void main() {
-    float scale = 0.40;
-    float hops = 2.0;
-    float x_time_interval = 0.85;
-    float y_time_interval = x_time_interval / (2.0 * hops);
-    float height = 0.5;
-    vec2 offset = vec2(
-        sliding_from_left_to_right(x_time_interval) * flipping_directions(x_time_interval) * (1.0 - scale),
-        ((sliding_from_left_to_right(y_time_interval) * flipping_directions(y_time_interval) + 1.0) / 4.0) - height);
-
-    gl_Position = vec4(
-        meshPosition * scale + offset,
-        0.0,
-        1.0);
-
-    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
-
-    uv.x = (flipping_directions(x_time_interval) + 1.0) / 2.0 - uv.x * flipping_directions(x_time_interval);
-}
-`,
-        "fragment": `#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`
+        "vertex": "glsl/hop.vs",
+        "fragment": "glsl/hop.fs"
     },
     "Hopper": {
         "transparent": 0x00FF00,
         "duration": 0.85,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-uniform float time;
-
-varying vec2 uv;
-
-float sliding_from_left_to_right(float time_interval) {
-    return (mod(time, time_interval) - time_interval * 0.5) / (time_interval * 0.5);
-}
-
-float flipping_directions(float time_interval) {
-    return 1.0 - 2.0 * mod(floor(time / time_interval), 2.0);
-}
-
-void main() {
-    float scale = 0.40;
-    float hops = 2.0;
-    float x_time_interval = 0.85 / 2.0;
-    float y_time_interval = x_time_interval / (2.0 * hops);
-    float height = 0.5;
-    vec2 offset = vec2(
-        sliding_from_left_to_right(x_time_interval) * flipping_directions(x_time_interval) * (1.0 - scale),
-        ((sliding_from_left_to_right(y_time_interval) * flipping_directions(y_time_interval) + 1.0) / 4.0) - height);
-
-    gl_Position = vec4(
-        meshPosition * scale + offset,
-        0.0,
-        1.0);
-
-    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
-
-    uv.x = (flipping_directions(x_time_interval) + 1.0) / 2.0 - uv.x * flipping_directions(x_time_interval);
-}
-`,
-        "fragment": `#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`
+        "vertex": "glsl/hopper.vs",
+        "fragment": "glsl/hopper.fs"
     },
     "Overheat": {
         "transparent": 0x00FF00,
         "duration": 0.85 / 8.0 * 2.0,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-uniform float time;
-
-varying vec2 uv;
-
-float sliding_from_left_to_right(float time_interval) {
-    return (mod(time, time_interval) - time_interval * 0.5) / (time_interval * 0.5);
-}
-
-float flipping_directions(float time_interval) {
-    return 1.0 - 2.0 * mod(floor(time / time_interval), 2.0);
-}
-
-void main() {
-    float scale = 0.40;
-    float hops = 2.0;
-    float x_time_interval = 0.85 / 8.0;
-    float y_time_interval = x_time_interval / (2.0 * hops);
-    float height = 0.5;
-    vec2 offset = vec2(
-        sliding_from_left_to_right(x_time_interval) * flipping_directions(x_time_interval) * (1.0 - scale),
-        ((sliding_from_left_to_right(y_time_interval) * flipping_directions(y_time_interval) + 1.0) / 4.0) - height);
-
-    gl_Position = vec4(
-        meshPosition * scale + offset,
-        0.0,
-        1.0);
-
-    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
-
-    uv.x = (flipping_directions(x_time_interval) + 1.0) / 2.0 - uv.x * flipping_directions(x_time_interval);
-}
-`,
-        "fragment": `#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y)) * vec4(1.0, 0.0, 0.0, 1.0);
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`
+        "vertex": "glsl/overheat.vs",
+        "fragment": "glsl/overheat.fs"
     },
     "Bounce": {
         "transparent": 0x00FF00,
         "duration": Math.PI / 5.0,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-
-uniform vec2 resolution;
-uniform float time;
-
-varying vec2 uv;
-
-void main() {
-    float scale = 0.30;
-    float period_interval = 5.0;
-    vec2 offset = vec2(0.0, (2.0 * abs(sin(time * period_interval)) - 1.0) * (1.0 - scale));
-    gl_Position = vec4(meshPosition * scale + offset, 0.0, 1.0);
-    uv = (meshPosition + 1.0) / 2.0;
-}
-`,
-        "fragment": `
-#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`,
+        "vertex": "glsl/bounce.vs",
+        "fragment": "glsl/bounce.fs",
     },
     "Circle": {
         "transparent": 0x00FF00,
         "duration": Math.PI / 4.0,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-
-uniform vec2 resolution;
-uniform float time;
-
-varying vec2 uv;
-
-vec2 rotate(vec2 v, float a) {
-	float s = sin(a);
-	float c = cos(a);
-	mat2 m = mat2(c, -s, s, c);
-	return m * v;
-}
-
-void main() {
-    float scale = 0.30;
-    float period_interval = 8.0;
-    float pi = 3.141592653589793238;
-    vec2 outer_circle = vec2(cos(period_interval * time), sin(period_interval * time)) * (1.0 - scale);
-    vec2 inner_circle = rotate(meshPosition * scale, (-period_interval * time) + pi / 2.0);
-    gl_Position = vec4(
-        inner_circle + outer_circle,
-        0.0,
-        1.0);
-    uv = (meshPosition + 1.0) / 2.0;
-}
-`,
-        "fragment": `
-#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    float speed = 1.0;
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`,
+        "vertex": "glsl/circle.vs",
+        "fragment": "glsl/circle.fs",
     },
     "Slide": {
         "transparent": 0x00FF00,
         "duration": 0.85 * 2,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-uniform float time;
-
-varying vec2 uv;
-
-float sliding_from_left_to_right(float time_interval) {
-    return (mod(time, time_interval) - time_interval * 0.5) / (time_interval * 0.5);
-}
-
-float flipping_directions(float time_interval) {
-    return 1.0 - 2.0 * mod(floor(time / time_interval), 2.0);
-}
-
-void main() {
-    float scale = 0.40;
-    float hops = 2.0;
-    float x_time_interval = 0.85;
-    float y_time_interval = x_time_interval / (2.0 * hops);
-    float height = 0.5;
-    vec2 offset = vec2(
-        sliding_from_left_to_right(x_time_interval) * flipping_directions(x_time_interval) * (1.0 - scale),
-        - height);
-
-    gl_Position = vec4(
-        meshPosition * scale + offset,
-        0.0,
-        1.0);
-
-    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
-
-    uv.x = (flipping_directions(x_time_interval) + 1.0) / 2.0 - uv.x * flipping_directions(x_time_interval);
-}
-`,
-        "fragment": `#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`
+        "vertex": "glsl/slide.vs",
+        "fragment": "glsl/slide.fs"
     },
     "Laughing": {
         "transparent": 0x00FF00,
         "duration": Math.PI / 12.0,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-uniform float time;
-
-varying vec2 uv;
-
-void main() {
-    float a = 0.3;
-    float t = (sin(24.0 * time) * a + a) / 2.0;
-
-    gl_Position = vec4(
-        meshPosition - vec2(0.0, t),
-        0.0,
-        1.0);
-    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
-}
-`,
-        "fragment": `#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`
+        "vertex": "glsl/laughing.vs",
+        "fragment": "glsl/laughing.fs"
     },
     "Blob": {
         "transparent": 0x00FF00,
         "duration": Math.PI / 3,
-        "vertex": `#version 100
-
-precision mediump float;
-
-attribute vec2 meshPosition;
-
-uniform vec2 resolution;
-uniform float time;
-
-varying vec2 uv;
-
-void main() {
-    float stretch = sin(6.0 * time) * 0.5 + 1.0;
-
-    vec2 offset = vec2(0.0, 1.0 - stretch);
-    gl_Position = vec4(
-        meshPosition * vec2(stretch, 2.0 - stretch) + offset,
-        0.0,
-        1.0);
-    uv = (meshPosition + vec2(1.0, 1.0)) / 2.0;
-}
-`,
-        "fragment": `#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`
+        "vertex": "glsl/blob.vs",
+        "fragment": "glsl/blob.fs"
     },
     "Go": {
         "transparent": 0x00FF00,
         "duration": 1 / 4,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-
-uniform vec2 resolution;
-uniform float time;
-
-varying vec2 uv;
-
-void main() {
-    gl_Position = vec4(meshPosition, 0.0, 1.0);
-    uv = (meshPosition + 1.0) / 2.0;
-}
-`,
-        "fragment": `
-#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-float slide(float speed, float value) {
-    return mod(value - speed * time, 1.0);
-}
-
-void main() {
-    float speed = 4.0;
-    gl_FragColor = texture2D(emote, vec2(slide(speed, uv.x), 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`,
+        "vertex": "glsl/go.vs",
+        "fragment": "glsl/go.fs",
     },
     "Elevator": {
         "transparent": 0x00FF00,
         "duration": 1 / 4,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-
-uniform vec2 resolution;
-uniform float time;
-
-varying vec2 uv;
-
-void main() {
-    gl_Position = vec4(meshPosition, 0.0, 1.0);
-    uv = (meshPosition + 1.0) / 2.0;
-}
-`,
-        "fragment": `
-#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-float slide(float speed, float value) {
-    return mod(value - speed * time, 1.0);
-}
-
-void main() {
-    float speed = 4.0;
-    gl_FragColor = texture2D(
-        emote,
-        vec2(uv.x, slide(speed, 1.0 - uv.y)));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`,
+        "vertex": "glsl/elevator.vs",
+        "fragment": "glsl/elevator.fs",
     },
     "Rain": {
         "transparent": 0x00FF00,
         "duration": 1,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-
-uniform vec2 resolution;
-uniform float time;
-
-varying vec2 uv;
-
-void main() {
-    gl_Position = vec4(meshPosition, 0.0, 1.0);
-    uv = (meshPosition + 1.0) / 2.0;
-}
-`,
-        "fragment": `
-#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-float slide(float speed, float value) {
-    return mod(value - speed * time, 1.0);
-}
-
-void main() {
-    float speed = 1.0;
-    gl_FragColor = texture2D(
-        emote,
-        vec2(mod(4.0 * slide(speed, uv.x), 1.0),
-             mod(4.0 * slide(speed, 1.0 - uv.y), 1.0)));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`,
+        "vertex": "glsl/rain.vs",
+        "fragment": "glsl/rain.fs",
     },
     "Pride": {
         "transparent": null,
         "duration": 2.0,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-
-uniform vec2 resolution;
-uniform float time;
-
-varying vec2 uv;
-
-void main() {
-    gl_Position = vec4(meshPosition, 0.0, 1.0);
-    uv = (meshPosition + 1.0) / 2.0;
-}
-`,
-        "fragment": `
-#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-vec3 hsl2rgb(vec3 c) {
-    vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),6.0)-3.0)-1.0, 0.0, 1.0);
-    return c.z + c.y * (rgb-0.5)*(1.0-abs(2.0*c.z-1.0));
-}
-
-void main() {
-    float speed = 1.0;
-
-    vec4 pixel = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    pixel.w = floor(pixel.w + 0.5);
-    pixel = vec4(mix(vec3(1.0), pixel.xyz, pixel.w), 1.0);
-    vec4 rainbow = vec4(hsl2rgb(vec3((time - uv.x - uv.y) * 0.5, 1.0, 0.80)), 1.0);
-    gl_FragColor = pixel * rainbow;
-}
-`,
+        "vertex": "glsl/pride.vs",
+        "fragment": "glsl/pride.fs"
     },
     "Hard": {
         "transparent": 0x00FF00,
         "duration": 2.0 * Math.PI / 32.0,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-
-uniform vec2 resolution;
-uniform float time;
-
-varying vec2 uv;
-
-void main() {
-    float zoom = 1.4;
-    float intensity = 32.0;
-    float amplitude = 1.0 / 8.0;
-    vec2 shaking = vec2(cos(intensity * time), sin(intensity * time)) * amplitude;
-    gl_Position = vec4(meshPosition * zoom + shaking, 0.0, 1.0);
-    uv = (meshPosition + 1.0) / 2.0;
-}
-`,
-        "fragment": `
-#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`,
+        "vertex": "glsl/hard.vs",
+        "fragment": "glsl/hard.fs",
     },
 	"Peek":{
         "transparent": 0x00FF00,
         "duration": 2.0 * Math.PI ,
-        "vertex": `#version 100
-precision mediump float;
-
-attribute vec2 meshPosition;
-
-uniform vec2 resolution;
-uniform float time;
-
-varying vec2 uv;
-
-void main() {
-    float time_clipped= mod(time * 2.0, (4.0 * 3.14));
-
-    float s1 = float(time_clipped < (2.0 * 3.14));
-    float s2 = 1.0 - s1;
-
-    float hold1 = float(time_clipped > (0.5 * 3.14) && time_clipped < (2.0 * 3.14));
-    float hold2 = 1.0 - float(time_clipped > (2.5 * 3.14) && time_clipped < (4.0 * 3.14));
-
-    float cycle_1 = 1.0 - ((s1 * sin(time_clipped) * (1.0 - hold1)) + hold1);
-    float cycle_2 = s2 * hold2 * (sin(time_clipped) - 1.0); 
-
-    gl_Position = vec4(meshPosition.x + 1.0 + cycle_1 + cycle_2 , meshPosition.y, 0.0, 1.0);
-    uv = (meshPosition + 1.0) / 2.0;
-}
-`,
-        "fragment": `
-#version 100
-
-precision mediump float;
-
-uniform vec2 resolution;
-uniform float time;
-
-uniform sampler2D emote;
-
-varying vec2 uv;
-
-void main() {
-    gl_FragColor = texture2D(emote, vec2(uv.x, 1.0 - uv.y));
-    gl_FragColor.w = floor(gl_FragColor.w + 0.5);
-}
-`, 
+        "vertex": "glsl/peek.vs",
+        "fragment": "glsl/peek.fs", 
 	},
 };
 

--- a/main.css
+++ b/main.css
@@ -68,3 +68,14 @@ p {
 #custom-preview {
     width: 112px;
 }
+
+#widget-filter[data-is-loading=true] #preview {
+    opacity: 0.5;
+}
+
+#widget-filter[data-is-loading=true] #select-filters:after {
+    content: "(Loading...)";
+    position: absolute;
+    padding-left: 8px;
+    opacity: 0.5;
+}


### PR DESCRIPTION
This PR moves inline shader source code into separate files located in the `glsl` directory.

Filters now specify their vertex and fragment shaders with a relative URL instead:

```js
"Hop": {
    "transparent": 0x00FF00,
    "duration": 0.85 * 2,
    "vertex": "glsl/hop.vs",
    "fragment": "glsl/hop.fs"
}
```

The shader sources are now fetched from network and are cached by the browser like any other resource. Usual caching rules apply and clients should have their caches invalidated when the Github Pages cache times out.

![image](https://user-images.githubusercontent.com/78752427/116900785-cf8e6700-ac41-11eb-9139-3e9153682420.png)

The render button is disabled while any shader is being loaded to prevent half of the gif being rendered with one shader and half with another if the shader is updated while gif is still being rendered.

Here's a demonstration of loading shaders with a very slow network connection. Note that switching to a cached shader is instant and does not show the placeholder:

https://user-images.githubusercontent.com/78752427/116900458-6dcdfd00-ac41-11eb-816e-6ec2a12b415b.mp4

