### PR TITLE
Fix storing context `vars` value as string

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -119,7 +119,7 @@ function loadFilterProgram(gl, filter, vertexAttribs) {
         for (var paramName in paramsInputs) {
             snapshot[paramName] = {
                 "uniform": uniforms[paramName],
-                "value": parseFloat(paramsInputs[paramName].value)
+                "value": Number(paramsInputs[paramName].value)
             };
         }
         return snapshot;

--- a/js/index.js
+++ b/js/index.js
@@ -142,7 +142,7 @@ function loadFilterProgram(gl, filter, vertexAttribs) {
         for (let paramName in paramsInputs) {
             snapshot[paramName] = {
                 "uniform": uniforms[paramName],
-                "value": paramsInputs[paramName].value
+                "value": parseFloat(paramsInputs[paramName].value)
             };
         }
         return snapshot;

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -175,7 +175,7 @@ function loadFilterProgram(gl: WebGLRenderingContext, filter: Filter, vertexAttr
         for (let paramName in paramsInputs) {
             snapshot[paramName] = {
                 "uniform": uniforms[paramName],
-                "value": paramsInputs[paramName].value
+                "value": Number(paramsInputs[paramName].value)
             };
         }
         return snapshot;


### PR DESCRIPTION
I was using variables in duration expression and noticed that it's concatenating value as strings.
For example if you change `duration` of Hop filter to `"duration": "interval + 2"` it calculates it as 0.852 instead of 2.85 here:
```js
const duration = Math.min(run_expr(program.duration, context), 60);
console.log({duration})
```