### PR TITLE
Fix absence check for `params` inputs

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -95,19 +95,19 @@ function loadFilterProgram(gl, filter, vertexAttribs) {
             const valuePreview = span(filter.params[paramName].init.toString());
             const valueInput = input("range");
 
-            if (filter.params[paramName].min) {
+            if (filter.params[paramName].min !== undefined) {
                 valueInput.att$("min", filter.params[paramName].min);
             }
 
-            if (filter.params[paramName].max) {
+            if (filter.params[paramName].max !== undefined) {
                 valueInput.att$("max", filter.params[paramName].max);
             }
 
-            if (filter.params[paramName].step) {
+            if (filter.params[paramName].step !== undefined) {
                 valueInput.att$("step", filter.params[paramName].step);
             }
 
-            if (filter.params[paramName].init) {
+            if (filter.params[paramName].init !== undefined) {
                 valueInput.att$("value", filter.params[paramName].init);
             }
 

--- a/js/index.js
+++ b/js/index.js
@@ -84,16 +84,16 @@ function loadFilterProgram(gl, filter, vertexAttribs) {
                 {
                     var valuePreview_1 = span(filter.params[paramName].init.toString());
                     var valueInput = input("range");
-                    if (filter.params[paramName].min) {
+                    if (filter.params[paramName].min !== undefined) {
                         valueInput.att$("min", filter.params[paramName].min);
                     }
-                    if (filter.params[paramName].max) {
+                    if (filter.params[paramName].max !== undefined) {
                         valueInput.att$("max", filter.params[paramName].max);
                     }
-                    if (filter.params[paramName].step) {
+                    if (filter.params[paramName].step !== undefined) {
                         valueInput.att$("step", filter.params[paramName].step);
                     }
-                    if (filter.params[paramName].init) {
+                    if (filter.params[paramName].init !== undefined) {
                         valueInput.att$("value", filter.params[paramName].init);
                     }
                     paramsInputs[paramName] = valueInput;

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -130,19 +130,19 @@ function loadFilterProgram(gl: WebGLRenderingContext, filter: Filter, vertexAttr
             const valuePreview = span(filter.params[paramName].init.toString());
             const valueInput = input("range");
 
-            if (filter.params[paramName].min) {
+            if (filter.params[paramName].min !== undefined) {
                 valueInput.att$("min", filter.params[paramName].min);
             }
 
-            if (filter.params[paramName].max) {
+            if (filter.params[paramName].max !== undefined) {
                 valueInput.att$("max", filter.params[paramName].max);
             }
 
-            if (filter.params[paramName].step) {
+            if (filter.params[paramName].step !== undefined) {
                 valueInput.att$("step", filter.params[paramName].step);
             }
 
-            if (filter.params[paramName].init) {
+            if (filter.params[paramName].init !== undefined) {
                 valueInput.att$("value", filter.params[paramName].init);
             }
 


### PR DESCRIPTION
There's no `min` attribute in Scale param for Hop filter. But it should be set to 0. 

<details>

<summary>
Dev tools screenshot
</summary>

![123123123123123123123123](https://user-images.githubusercontent.com/4366033/121417960-21c65480-c973-11eb-8077-f0c9a820c9b5.png)

</details>

But for `<input type="range">` it's zero by default so it's fine. But I couldn't set init value to 0.0. This PR fixes it.