### PR TITLE
Change "any" gif typings to "GIF"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/gif.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@types/gif.js/-/gif.js-0.2.0.tgz",
-      "integrity": "sha512-7Mnnpo5PE3ASo6VQ4jP84MSs09uYLAe4hI1USnzaK1Ij/rIvqWUM81wJveZX1uvmDBnIqf31XtKxEO6DobM/tQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/gif.js/-/gif.js-0.2.1.tgz",
+      "integrity": "sha512-oZAPX8pgueiAngu3HfynjdtsDNt4EiD1fs5An//LtBKvOdnc4Wq8/S7GkAKpP80+29WyVwGEGVEUXPyFhbQ2+g==",
       "dev": true
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/tsoding/emoteJAM#readme",
   "devDependencies": {
-    "@types/gif.js": "^0.2.0",
+    "@types/gif.js": "^0.2.1",
     "typescript": "^4.3.2"
   }
 }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -543,7 +543,7 @@ window.onload = () => {
 
     // TODO(#50): extract "renderer" as a separate grecha.js component
     // Similar to imageSelector and filterSelector
-    let gif: any | undefined = undefined;
+    let gif: GIF | undefined = undefined;
     const renderButton = document.getElementById("render");
     if (renderButton === null) {
         throw new Error('Could not find "render"');


### PR DESCRIPTION
# Changelog

- Update `@types/gif.js` package to 0.2.1
- Change gif type definition from `any` to `GIF`

New [@types.gif.js](https://www.npmjs.com/package/@types/gif.js) version has type definitions for dithering methods, setOption(s) and abort. Hope with that we can use GIF type definitions, instead of `any` and maybe solve #74 .