### PR TITLE
Fix: Eval even positioned negatives

### DIFF
--- a/ts/eval.ts
+++ b/ts/eval.ts
@@ -4,6 +4,7 @@ type BinaryOpFunc = (lhs: number, rhs: number) => number;
 enum BinaryPrec {
     PREC0 = 0,
     PREC1,
+    PREC2,
     COUNT_PRECS
 }
 
@@ -19,19 +20,19 @@ const BINARY_OPS: {[op in BinaryOp]: BinaryOpDef} = {
     },
     '-': {
         func: (lhs, rhs) => lhs - rhs,
-        prec: BinaryPrec.PREC0
+        prec: BinaryPrec.PREC1
     },
     '*': {
         func: (lhs, rhs) => lhs * rhs,
-        prec: BinaryPrec.PREC1
+        prec: BinaryPrec.PREC2
     },
     '/': {
         func: (lhs, rhs) => lhs / rhs,
-        prec: BinaryPrec.PREC1
+        prec: BinaryPrec.PREC2
     },
     '%': {
         func: (lhs, rhs) => lhs % rhs,
-        prec: BinaryPrec.PREC1
+        prec: BinaryPrec.PREC2
     }
 };
 


### PR DESCRIPTION
Expressions like `1-2+3` return -4 because everything on rhs enters a chain of binary operations and gets evaluated,
the PREC2 is obviously to maintain the difference between -+ and the rest